### PR TITLE
Fix today-badge showing internal cycle index instead of display day number

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,8 @@
 
             function applyProgramDay() {
                 const today = currentProgramDay(new Date());
-                document.getElementById("today-day-number").textContent = today;
+                const displayDay = { 0: 0, 1: 1, 2: 0, 3: 2 }[today];
+                document.getElementById("today-day-number").textContent = displayDay;
                 const sectionMap = { 0: "section-day0b", 1: "section-day1", 2: "section-day0", 3: "section-day2" };
                 Object.values(sectionMap).forEach(id => {
                     document.getElementById(id).classList.remove('active', 'inactive');


### PR DESCRIPTION
The 4-step internal cycle (0→1→2→3) maps to day types (0→1→0→2), but
the header badge was displaying the raw cycle index. On rest days after
push (internal step 2) it showed "День 2" instead of "День 0".

https://claude.ai/code/session_01Pq2zqEJQ8A4KoFiS4SMTtr